### PR TITLE
Error handling optimised on -l 

### DIFF
--- a/defines.go
+++ b/defines.go
@@ -96,6 +96,14 @@ type xmlProps struct {
 	LastModified string   `xml:"response>propstat>prop>getlastmodified"`
 }
 
+type xmlPropsError struct {
+	CalNo 			string
+	Url 				string
+	XMLName 		xml.Name 	`xml:"error"`
+	Exception 	string 		`xml:"exception"`
+	Message 		string 		`xml:"message"`
+}
+
 type calProps struct {
 	calNo       int
 	displayName string

--- a/defines.go
+++ b/defines.go
@@ -6,32 +6,36 @@ import (
 	"time"
 )
 
-var err string
-var homedir string = os.Getenv("HOME")
-var editor string = os.Getenv("EDITOR")
-var configLocation string = (homedir + "/" + ConfigDir + "/config.json")
-var cacheLocation string = (homedir + "/" + CacheDir)
-var versionLocation string = (cacheLocation + "/version.json")
-var timezone, _ = time.Now().Zone()
-var xmlContent []byte
-var showInfo bool
-var showTeamsLinks bool
-var showFilename bool
-var displayFlag bool
-var startDate string
-var endDate string
-var startDateUTC string
-var endDateUTC string
-var summary string
-var toFile bool
-var elements []Event
-var qcalversion string = "0.9.3"
+var (
+	err             string
+	homedir         string = os.Getenv("HOME")
+	editor          string = os.Getenv("EDITOR")
+	configLocation  string = (homedir + "/" + ConfigDir + "/config.json")
+	cacheLocation   string = (homedir + "/" + CacheDir)
+	versionLocation string = (cacheLocation + "/version.json")
+	timezone, _            = time.Now().Zone()
+	xmlContent      []byte
+	showInfo        bool
+	showTeamsLinks  bool
+	showFilename    bool
+	displayFlag     bool
+	startDate       string
+	endDate         string
+	startDateUTC    string
+	endDateUTC      string
+	summary         string
+	toFile          bool
+	elements        []Event
+	qcalversion     string = "0.9.3"
+)
 
-var colorBlock string = "|"
-var currentDot string = "•"
-var Colors = [10]string{"\033[0;31m", "\033[0;32m", "\033[1;33m", "\033[1;34m", "\033[1;35m", "\033[1;36m", "\033[1;37m", "\033[1;38m", "\033[1;39m", "\033[1;40m"}
-var showColor bool = true
-var showWeekday bool = true
+var (
+	colorBlock  string = "|"
+	currentDot  string = "•"
+	Colors             = [10]string{"\033[0;31m", "\033[0;32m", "\033[1;33m", "\033[1;34m", "\033[1;35m", "\033[1;36m", "\033[1;37m", "\033[1;38m", "\033[1;39m", "\033[1;40m"}
+	showColor   bool   = true
+	showWeekday bool   = true
+)
 
 const (
 	ConfigDir      = ".config/qcal"
@@ -44,7 +48,7 @@ const (
 	IcsFormat   = "20060102T150405"
 	IcsFormatZ  = "20060102T150405Z"
 	IcsFormatTZ = "TZID=MST:20060102T150405"
-	//IcsFormatTZ         = "20060102T150405Z -0700"
+	// IcsFormatTZ         = "20060102T150405Z -0700"
 	IcsFormatWholeDay   = "20060102"
 	IcsFormatWholeMonth = "200601"
 	IcsFormatMonthDay   = "0102"
@@ -97,11 +101,11 @@ type xmlProps struct {
 }
 
 type xmlPropsError struct {
-	CalNo 			string
-	Url 				string
-	XMLName 		xml.Name 	`xml:"error"`
-	Exception 	string 		`xml:"exception"`
-	Message 		string 		`xml:"message"`
+	CalNo     string
+	Url       string
+	XMLName   xml.Name `xml:"error"`
+	Exception string   `xml:"exception"`
+	Message   string   `xml:"message"`
 }
 
 type calProps struct {

--- a/helpers.go
+++ b/helpers.go
@@ -371,7 +371,11 @@ func uploadICS(calNumber string, eventFilePath string, eventEdit bool) (status s
 			eventFileName = genUUID() + `.ics` // no edit, so new filename
 		}
 	}
-	req, _ := http.NewRequest("PUT", config.Calendars[calNo].Url+eventFileName, strings.NewReader(eventICS))
+	// clean all METHODs from input ics since it's not allowed on a PUT
+	methodRegexp := regexp.MustCompile(`METHOD\:.*`)
+	cleanedICS := methodRegexp.ReplaceAllString(eventICS," ")
+	req, _ := http.NewRequest("PUT", config.Calendars[calNo].Url+eventFileName, strings.NewReader(cleanedICS))
+
 	req.SetBasicAuth(config.Calendars[calNo].Username, config.Calendars[calNo].password())
 	req.Header.Add("Content-Type", "text/calendar; charset=utf-8")
 

--- a/helpers.go
+++ b/helpers.go
@@ -90,7 +90,7 @@ func getCalProp(calNo int, p *[]calProps, wg *sync.WaitGroup) {
 		xmlProps := xmlProps{}
 		err = xml.Unmarshal(xmlContent, &xmlProps)
 		if err != nil {
-			fmt.Println(string(config.Calendars[calNo].Url))
+			log.Println(string(config.Calendars[calNo].Url))
 			log.Println(err)
 
 			// parse the xml error message

--- a/helpers.go
+++ b/helpers.go
@@ -30,7 +30,7 @@ func getConf() *configStruct {
 
 	conf := configStruct{}
 	err = json.Unmarshal(configData, &conf)
-	//fmt.Println(conf)
+	// fmt.Println(conf)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -74,7 +74,6 @@ func getCalProp(calNo int, p *[]calProps, wg *sync.WaitGroup) {
 	cli := &http.Client{Transport: tr}*/
 	cli := &http.Client{}
 	resp, err := cli.Do(req)
-
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -94,18 +93,18 @@ func getCalProp(calNo int, p *[]calProps, wg *sync.WaitGroup) {
 			fmt.Println(string(config.Calendars[calNo].Url))
 			log.Println(err)
 
-			// parse the xml error message 
-			xmlServerError := xmlPropsError{}	
+			// parse the xml error message
+			xmlServerError := xmlPropsError{}
 			err2 := xml.Unmarshal(xmlContent, &xmlServerError)
 			if err2 != nil {
 				// if it's not possible to parse the xml response
 				log.Println(string("Error parsing server xml error response"))
 				log.Fatal(err2)
 			}
-		
+
 			log.Println(string(xmlServerError.Exception))
 			log.Println(string(xmlServerError.Message))
-				
+
 		}
 		displayName = xmlProps.DisplayName
 	}
@@ -155,8 +154,8 @@ func (e Event) fancyOutput() {
 		}
 		fmt.Print(e.Start.Format(dateFormat) + ` `)
 		fmt.Printf(`%6s`, ` `)
-		//fmt.Println(e)
-		//if e.Start.Format(dateFormat) == e.End.Format(dateFormat) {
+		// fmt.Println(e)
+		// if e.Start.Format(dateFormat) == e.End.Format(dateFormat) {
 		if e.Start.Add(time.Hour*24) == e.End {
 			fmt.Println(e.Summary)
 		} else {
@@ -211,14 +210,15 @@ func (e Event) fancyOutput() {
 			fmt.Println(path.Base(e.Href))
 		}
 	}
-	//fmt.Println()
+	// fmt.Println()
 }
+
 func (e Event) icsOutput() {
 	// whole day or greater
 	fmt.Println(`Appointment
 ===========`)
-	//fmt.Printf(`Summary:%6s`, ` `)
-	//fmt.Print(e.Summary)
+	// fmt.Printf(`Summary:%6s`, ` `)
+	// fmt.Print(e.Summary)
 	fmt.Printf(`Summary:%6s`+e.Summary, ` `)
 	fmt.Println(``)
 	fmt.Printf(`Start:%8s`+e.Start.Format(RFC822), ` `)
@@ -255,7 +255,7 @@ func isNumeric(s string) bool {
 
 func deleteEvent(calNumber string, eventFilename string) (status string) {
 	calNo, _ := strconv.ParseInt(calNumber, 0, 64)
-	//fmt.Println(config.Calendars[calNo].Url + eventFilename)
+	// fmt.Println(config.Calendars[calNo].Url + eventFilename)
 
 	if eventFilename == "" {
 		log.Fatal("No event filename given")
@@ -279,7 +279,7 @@ func editEvent(calNumber string, eventFilename string) (status string) {
 	toFile = true
 	eventEdit := true
 	dumpEvent(calNumber, eventFilename, toFile)
-	//fmt.Println(appointmentEdit)
+	// fmt.Println(appointmentEdit)
 	filePath := cacheLocation + "/" + eventFilename
 	fileInfo, err := os.Stat(filePath)
 	if err != nil {
@@ -310,7 +310,7 @@ func editEvent(calNumber string, eventFilename string) (status string) {
 
 func dumpEvent(calNumber string, eventFilename string, toFile bool) (status string) {
 	calNo, _ := strconv.ParseInt(calNumber, 0, 64)
-	//fmt.Println(config.Calendars[calNo].Url + eventFilename)
+	// fmt.Println(config.Calendars[calNo].Url + eventFilename)
 
 	req, _ := http.NewRequest("GET", config.Calendars[calNo].Url+eventFilename, nil)
 	req.SetBasicAuth(config.Calendars[calNo].Username, config.Calendars[calNo].password())
@@ -321,13 +321,13 @@ func dumpEvent(calNumber string, eventFilename string, toFile bool) (status stri
 	if err != nil {
 		log.Fatal(err)
 	}
-	//fmt.Println(resp.Status)
+	// fmt.Println(resp.Status)
 	xmlContent, _ := io.ReadAll(resp.Body)
 
 	if toFile {
 		// create cache dir if not exists
 		os.MkdirAll(cacheLocation, os.ModePerm)
-		err := os.WriteFile(cacheLocation+"/"+eventFilename, xmlContent, 0644)
+		err := os.WriteFile(cacheLocation+"/"+eventFilename, xmlContent, 0o644)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -340,7 +340,7 @@ func dumpEvent(calNumber string, eventFilename string, toFile bool) (status stri
 
 func uploadICS(calNumber string, eventFilePath string, eventEdit bool) (status string) {
 	calNo, _ := strconv.ParseInt(calNumber, 0, 64)
-	//fmt.Println(config.Calendars[calNo].Url + eventFilePath)
+	// fmt.Println(config.Calendars[calNo].Url + eventFilePath)
 
 	var icsData string
 	var eventICS string
@@ -352,13 +352,13 @@ func uploadICS(calNumber string, eventFilePath string, eventEdit bool) (status s
 		for scanner.Scan() {
 			icsData += scanner.Text() + "\n"
 		}
-		//eventICS, _ = explodeEvent(&icsData)
+		// eventICS, _ = explodeEvent(&icsData)
 		eventICS = icsData
 		eventFileName = genUUID() + `.ics`
 		fmt.Println(eventICS)
 
 	} else {
-		//eventICS, err := os.ReadFile(cacheLocation + "/" + eventFilename)
+		// eventICS, err := os.ReadFile(cacheLocation + "/" + eventFilename)
 		eventICSByte, err := os.ReadFile(eventFilePath)
 		if err != nil {
 			log.Fatal(err)
@@ -405,7 +405,6 @@ func displayICS() {
 	if err := scanner.Err(); err != nil {
 		log.Println(err)
 	}
-
 }
 
 func (c *calendar) password() string {

--- a/helpers.go
+++ b/helpers.go
@@ -81,7 +81,7 @@ func getCalProp(calNo int, p *[]calProps, wg *sync.WaitGroup) {
 
 	xmlContent, _ := io.ReadAll(resp.Body)
 
-	//fmt.Println(string(xmlContent))
+	// fmt.Println(string(xmlContent))
 	defer resp.Body.Close()
 
 	var displayName string
@@ -91,7 +91,21 @@ func getCalProp(calNo int, p *[]calProps, wg *sync.WaitGroup) {
 		xmlProps := xmlProps{}
 		err = xml.Unmarshal(xmlContent, &xmlProps)
 		if err != nil {
-			log.Fatal(err)
+			fmt.Println(string(config.Calendars[calNo].Url))
+			log.Println(err)
+
+			// parse the xml error message 
+			xmlServerError := xmlPropsError{}	
+			err2 := xml.Unmarshal(xmlContent, &xmlServerError)
+			if err2 != nil {
+				// if it's not possible to parse the xml response
+				log.Println(string("Error parsing server xml error response"))
+				log.Fatal(err2)
+			}
+		
+			log.Println(string(xmlServerError.Exception))
+			log.Println(string(xmlServerError.Message))
+				
 		}
 		displayName = xmlProps.DisplayName
 	}


### PR DESCRIPTION
If something is wrong with a calendar the server provides a xml error response but on the console you only get the message that the returning namespace isn't expected. 
So parsing the error xml in case of an error and showing the server response help finding errors.

Also this pull request removes METHOD from to be imported .ics files so that on a PUT there is no problem for importing. 

